### PR TITLE
stop get_original_data.sh from copying the entirety of the root drive

### DIFF
--- a/get_original_data.sh
+++ b/get_original_data.sh
@@ -23,7 +23,7 @@ mkdir -p original/PKIMetadata/2000
 
 #Copy latest version as base (idk if this is reliable)
 if [ "$HIGHESTVERSIONAPPARENTLY" != "" ]; then
-	cp -rvf "$HIGHESTVERSIONAPPARENTLY"/. original/PKIMetadata/2000
+    cp -rvf "$HIGHESTVERSIONAPPARENTLY"/. original/PKIMetadata/2000
 else
     echo "Variable HIGHESTVERSIONAPPARENTLY returned empty, failing."
     exit 1

--- a/get_original_data.sh
+++ b/get_original_data.sh
@@ -10,6 +10,10 @@ then
 fi
 # Search directory for versions
 HIGHESTVERSIONAPPARENTLY=$(find  "$HOME/.config/$CHROME/PKIMetadata/" -maxdepth 1 -mindepth 1 -type d| head -n 1)
+if [ -z ${HIGHESTVERSIONAPPARENTLY} ]; then
+	echo "Failed to find PKIMetadata directory"
+	exit 1
+fi
 
 #Let the user know what version we are on
 echo "$HIGHESTVERSIONAPPARENTLY"
@@ -18,7 +22,12 @@ echo "$HIGHESTVERSIONAPPARENTLY"
 mkdir -p original/PKIMetadata/2000
 
 #Copy latest version as base (idk if this is reliable)
-cp -rvf "$HIGHESTVERSIONAPPARENTLY"/. original/PKIMetadata/2000
+if [ "$HIGHESTVERSIONAPPARENTLY" != "" ]; then
+	cp -rvf "$HIGHESTVERSIONAPPARENTLY"/. original/PKIMetadata/2000
+else
+    echo "Variable HIGHESTVERSIONAPPARENTLY returned empty, failing."
+    exit 1
+fi
 
 #Remove metadata and fingerprint(just sha256 of manifest) to be accepted
 rm -rvf original/PKIMetadata/2000/_metadata


### PR DESCRIPTION
title