### PR TITLE
Make inshim.sh way better

### DIFF
--- a/inshim.sh
+++ b/inshim.sh
@@ -1,13 +1,45 @@
 #!/bin/bash
-mount /dev/sda1 /mnt/stateful_partition/
-mkfs.ext4 -F /dev/mmcblk0p1 # This only wipes the stateful partition
-mount /dev/mmcblk0p1 /tmp
-if [ "$(id -u)" -ne 0 ]
-then
-    echo "Run this as root"
+
+[ "$EUID" -ne 0 ] && echo "Run this as root"
+
+get_largest_cros_blockdev() {
+	local largest size dev_name tmp_size remo
+	size=0
+	for blockdev in /sys/block/*; do
+		dev_name="${blockdev##*/}"
+		echo -e "$dev_name" | grep -q '^\(loop\|ram\)' && continue
+		tmp_size=$(cat "$blockdev"/size)
+		remo=$(cat "$blockdev"/removable)
+		if [ "$tmp_size" -gt "$size" ] && [ "${remo:-0}" -eq 0 ]; then
+			case "$(sfdisk -d "/dev/$dev_name" 2>/dev/null)" in
+				*'name="STATE"'*'name="KERN-A"'*'name="ROOT-A"'*)
+					largest="/dev/$dev_name"
+					size="$tmp_size"
+					;;
+			esac
+		fi
+	done
+	echo -e "$largest"
+}
+
+format_part_number() {
+	echo -n "$1"
+	echo "$1" | grep -q '[0-9]$' && echo -n p
+	echo "$2"
+}
+
+mount /dev/disk/by-label/STATE /mnt/stateful_partition/
+cros_dev="$(get_largest_cros_blockdev)"
+if [ -z "$cros_dev" ]; then
+	echo "No CrOS SSD found on device. Failing."
+    exit 1
 fi
+stateful=$(format_part_number "$cros_dev" 1)
+mkfs.ext4 -F "$stateful" # This only wipes the stateful partition
+mount "$stateful" /tmp
 mkdir -p /tmp/unencrypted
 cp /mnt/stateful_partition/usr/share/packeddata/. /tmp/unencrypted/ -rvf
 chown 1000 /tmp/unencrypted/PKIMetadata -R
+rm /tmp/.developer_mode
 umount /tmp
 crossystem disable_dev_request=1


### PR DESCRIPTION
Dynamically get the stateful partition on the internal storage along with the one on the shim. Also remove .developer_mode to avoid clobber and check if running as root at the earliest possible point in the script.